### PR TITLE
chore(deps): change browser-process-hrtime to browser-hrtime

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 
 // Browserify's process implementation doesn't have hrtime, and this package is small so not much of a burden for
 // Node.js users.
-const hrtime = require("browser-process-hrtime");
+const hrtime = require("browser-hrtime");
 
 function toMS([sec, nanosec]) {
   return sec * 1e3 + nanosec / 1e6;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "browser-process-hrtime": "^1.0.0"
+    "browser-hrtime": "^1.1.5"
   },
   "devDependencies": {
     "eslint": "^4.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,15 +646,15 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+browser-hrtime@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/browser-hrtime/-/browser-hrtime-1.1.5.tgz#23108b9eb1e09caea48b22857647969a32d817c9"
+  integrity sha512-68XbABub674JXvVIPuI2c13On5FvjSaKY7hF28OKMsQdmIc57iL9gqqgy3PWgB7dhE4PdxyqsWkgPiBtfElyFw==
+
 browser-process-hrtime@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
   integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
-
-browser-process-hrtime@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
-  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
 browser-resolve@^1.11.3:
   version "1.11.3"


### PR DESCRIPTION
When trying to use w3c-hr-time in Angular its crashes on `process is not defined`
![image](https://user-images.githubusercontent.com/5851280/80760374-79c04400-8b41-11ea-8bc8-99b5aa072907.png)
This happens because of how `browser-process-hrtime`  check if process.hrtime defined.
```js
module.exports = process.hrtime || hrtime
```
I tried to make some tests and I guess it depends on which bundler you are using, as it did work for me in browserify (probably they are emulating `process` variable). But Angular+webpack crashes. Didn't test it in React, but I think it will crash there too.

`browser-process-hrtime` looks like not maintained anymore (last commit was 2 years ago and open pull request from December 2018).
So I created a similar package [browser-hrtime](https://www.npmjs.com/package/browser-hrtime) that solves this problem (also add support for process.hrtime.bigint(), tests for browser, and in general made my best to make it good enough).

So I propose you to take a look, and of course here is a screenshot after fix:
![image](https://user-images.githubusercontent.com/5851280/80760413-8a70ba00-8b41-11ea-91d8-71c062d6b06b.png)

I tried to google issues about it, actually didn't found much, but I think it still should be fixed :)

https://github.com/thenativeweb/measure-time/issues/1
https://github.com/HubSpot/BuckyClient/issues/23
https://github.com/jhuckaby/canvas-plus/issues/5